### PR TITLE
Find the names in many more ways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-.idea/workspace.xml
-.idea/dataSources.ids
-.idea/dataSources/
-.idea/vcs.xml
+.idea
+tmp
 
 *.py[cod]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-.idea
+.idea/workspace.xml
+.idea/dataSources.ids
+.idea/dataSources/
+.idea/vcs.xml
+
 tmp
 
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # picasa2digikam
 
-A script to migrate Picasa metadata from its `.picasa.ini` files (does not require Picasa to be installed and therefore
-does not require Windows) to the [digiKam](https://www.digikam.org/) database (does not write into the file system, so
-the original files should remain untouched).
+A script to migrate Picasa metadata from its `.picasa.ini` files and/or `contacts.xml` file to the 
+[digiKam](https://www.digikam.org/) database.
+
+It does not require Picasa to be installed and therefore does not require Windows. It does not write into the original 
+Picasa file system, so the original files should remain untouched.  However, it does write to the digikam4.db file, so 
+make sure you back that up (although this script also creates backups too).  
+
+'contacts.xml' usually contains more accurate name information, so locate and provide the file path to it if possible.  
+
+In the rare instance where a face was identified in the .ini file without a corresponding name in either .ini or 
+contacts.xml, this script generates a name using the hashed contact ID in the form of
+`.NoName-[hashed-contact-id]-from-rect64`. E.g. `.NoName-da61ef7edfd692c5-from-rect64`
+
+
 
 ## Supported metadata
 
@@ -18,17 +29,25 @@ the original files should remain untouched).
       touches every single file on disk, which might not be desirable) as an alternative way of migrating your face
       tags.
 
+## Where to find contacts.xml?
+
+* Can be found at %LocalAppData%\Google\Picasa2\contacts\contacts.xml
+* Also can be obtained from performing a backup operation from within Picasa.  It will be in the backup location as
+  `$Application Data\Google\Picasa2\contacts\backup.xml`
+
 ## Installation
 
 Clone the repository and `cd` into it. Install `pip3 install psutil`. On Windows, also `pip3 install pywin32`.
 
 ## Suggested usage
 
-This script writes into the digiKam database. If you already have photos in digiKam, you should *at least* make a
-backup. Furthermore, this script has been tested only when writing into an "empty" digiKam instance, so you might get
-better results by starting with an empty instance too. You may also want to make a backup of the photo directories,
-though the script doesn't write there. Depending on your metadata sync settings in digiKam, digiKam itself may (or not)
-write some of the added metadata to EXIF tags in your photos.
+This script writes into the digiKam database. If you already have photos in digiKam, you should *at least* make a backup. 
+Furthermore, testing shows this script works best when writing into an "empty" digiKam instance.  If you already have 
+faces identified prior to running this script, you might get duplicate entries if the digiKam name does not match the name 
+this script found.
+
+You may also want to make a backup of the photo directories, though the script doesn't write there. Depending on your 
+metadata sync settings in digiKam, digiKam itself may (or not) write some of the added metadata to EXIF tags in your photos.
 
 0. Optional: As this is your last chance to make edits in Picasa that will also be reflected in digiKam, you may want to
    do some cleanups there:
@@ -46,12 +65,20 @@ write some of the added metadata to EXIF tags in your photos.
    ./main.py --dry_run \
        --photos_dir='C:\Users\user\...' \
        --digikam_db='C:\Users\user\...\digikam4.db'
+       --contacts='%LocalAppData%\Google\Picasa2\contacts\contacts.xml'
    ```
    In this command, `--photos_dir` must point to the same directory you configured in step 3 above, or a sub-directory
-   thereof, and `--digikam_db` must point to the `digikam4.db` file under the directory configured in step 2 above.
-6. Make sure there were no errors, and take a look at relevant-looking warnings. Debug if necessary.
+   thereof, and `--digikam_db` must point to the `digikam4.db` file under the directory configured in step 2 above.  
+   `--contacts` is optional but highly recommended.
+6. Make sure there were no errors, and take a look at relevant-looking warnings. Debug if necessary.  Sometimes the .ini 
+   file is corrupted (probably due to Picasa crashing in the middle of updating an .ini file) -- you will need to 
+   edit the .ini file in such cases)
 7. Close digiKam (to prevent concurrent access to the database).
 8. Execute the same command without `--dry_run` to carry out the migration.
-9. Open digiKam again and do some spot checks to make sure the migration worked as intended.
+9. Open digiKam again and do some spot checks to make sure the migration worked as intended.  Note: digiKam may have 
+    already detected faces during the initial library scan -- in this case you may end up with overlapping face 
+    rectangles.  If this migration started from a "clean" digiKam, you can just move all the "Unknown" faces to 
+    "Ignore", otherise it may take some time to manually clean up from within digiKam (or by editing digikam4.db using
+    an SQL client).  
 10. If you want, you can now run digiKam's face detection to detect faces that Picasa hadn't detected or that were still
-    in the "Unknown" folder in Picasa.
+    in the "Unknown" folder in Picasa.  

--- a/README.md
+++ b/README.md
@@ -3,23 +3,9 @@
 A script to migrate Picasa metadata from its `.picasa.ini` files and/or `contacts.xml` file to the 
 [digiKam](https://www.digikam.org/) database.
 
-It does not require Picasa to be installed and therefore does not require Windows. It does not write into the original 
-Picasa file system, so the original files should remain untouched.  However, it does write to the `digikam4.db` file, so 
-make sure you back that up (although this script also creates backups too).  
+It does not require Picasa to be installed and therefore does not require Windows. 
 
-`contacts.xml` usually contains more accurate name information, so locate and provide the file path to it if possible.  
-
-In large old collections, there may be some inconsistencies between .ini files due to crashes in Picasa, manual moving, 
-etc.  A lot of inconsistencies can be resolved by using the `contacts.xml` file.  If no `contacts.xml` is available, this 
-script tries to workaround some of these issues.  For example:
-
-* In the rare instance where a face was identified in the .ini file without a corresponding name in either .ini or 
-  `contacts.xml`, this script generates a name using the hashed contact ID in the form of
-  `.NoName-[hashed-contact-id]-from-rect64`. E.g. `.NoName-da61ef7edfd692c5-from-rect64`
-
-* In another rare instance where a face was identified multiple times in .ini files, this script generates a guessed name
-  using a concatenation of all the names found separated by `|`.  E.g. `Marsha|Marshia|Marcia`
-
+It does not write into the original Picasa file system, so the original files should remain untouched.  
 
 
 ## Supported metadata
@@ -71,7 +57,7 @@ metadata sync settings in digiKam, digiKam itself may (or not) write some of the
    ```bash
    ./main.py --dry_run \
        --photos_dir='C:\Users\user\...' \
-       --digikam_db='C:\Users\user\...\digikam4.db'
+       --digikam_db='C:\Users\user\...\digikam4.db' \
        --contacts='%LocalAppData%\Google\Picasa2\contacts\contacts.xml'
    ```
    In this command, `--photos_dir` must point to the same directory you configured in step 3 above, or a sub-directory
@@ -89,3 +75,20 @@ metadata sync settings in digiKam, digiKam itself may (or not) write some of the
     an SQL client).
 10. If you want, you can now run digiKam's face detection to detect faces that Picasa hadn't detected or that were still
     in the "Unknown" folder in Picasa.
+
+## Operation Details
+
+The script writes to the `digikam4.db` file and creates a backup.  However it is also recommended you make a backup too.  
+
+`contacts.xml` usually contains more accurate name information, so locate and provide the file path to it if possible.  
+
+In large old collections, there may be some inconsistencies between .ini files due to crashes in Picasa, manual moving, 
+etc.  A lot of inconsistencies can be resolved by using the `contacts.xml` file.  If no `contacts.xml` is available, this 
+script tries to work around some of these issues.  For example:
+
+* In the rare instance where a face was identified in the .ini file without a corresponding name in either .ini or 
+  `contacts.xml`, this script generates a name using the hashed contact ID in the form of
+  `.NoName-[hashed-contact-id]-from-rect64`. E.g. `.NoName-da61ef7edfd692c5-from-rect64`
+
+* In another rare instance where a face was identified multiple times in .ini files, this script generates a guessed name
+  using a concatenation of all the sorted names found separated by `|`.  E.g. `Marcia|Marsha|Marshia|`

--- a/README.md
+++ b/README.md
@@ -4,14 +4,21 @@ A script to migrate Picasa metadata from its `.picasa.ini` files and/or `contact
 [digiKam](https://www.digikam.org/) database.
 
 It does not require Picasa to be installed and therefore does not require Windows. It does not write into the original 
-Picasa file system, so the original files should remain untouched.  However, it does write to the digikam4.db file, so 
+Picasa file system, so the original files should remain untouched.  However, it does write to the `digikam4.db` file, so 
 make sure you back that up (although this script also creates backups too).  
 
-'contacts.xml' usually contains more accurate name information, so locate and provide the file path to it if possible.  
+`contacts.xml` usually contains more accurate name information, so locate and provide the file path to it if possible.  
 
-In the rare instance where a face was identified in the .ini file without a corresponding name in either .ini or 
-contacts.xml, this script generates a name using the hashed contact ID in the form of
-`.NoName-[hashed-contact-id]-from-rect64`. E.g. `.NoName-da61ef7edfd692c5-from-rect64`
+In large old collections, there may be some inconsistencies between .ini files due to crashes in Picasa, manual moving, 
+etc.  A lot of inconsistencies can be resolved by using the `contacts.xml` file.  If no `contacts.xml` is available, this 
+script tries to workaround some of these issues.  For example:
+
+* In the rare instance where a face was identified in the .ini file without a corresponding name in either .ini or 
+  `contacts.xml`, this script generates a name using the hashed contact ID in the form of
+  `.NoName-[hashed-contact-id]-from-rect64`. E.g. `.NoName-da61ef7edfd692c5-from-rect64`
+
+* In another rare instance where a face was identified multiple times in .ini files, this script generates a guessed name
+  using a concatenation of all the names found separated by `|`.  E.g. `Marsha|Marshia|Marcia`
 
 
 
@@ -29,9 +36,9 @@ contacts.xml, this script generates a name using the hashed contact ID in the fo
       touches every single file on disk, which might not be desirable) as an alternative way of migrating your face
       tags.
 
-## Where to find contacts.xml?
+## Where to find `contacts.xml`?
 
-* Can be found at %LocalAppData%\Google\Picasa2\contacts\contacts.xml
+* Can be found at `%LocalAppData%\Google\Picasa2\contacts\contacts.xml`
 * Also can be obtained from performing a backup operation from within Picasa.  It will be in the backup location as
   `$Application Data\Google\Picasa2\contacts\backup.xml`
 
@@ -78,7 +85,7 @@ metadata sync settings in digiKam, digiKam itself may (or not) write some of the
 9. Open digiKam again and do some spot checks to make sure the migration worked as intended.  Note: digiKam may have 
     already detected faces during the initial library scan -- in this case you may end up with overlapping face 
     rectangles.  If this migration started from a "clean" digiKam, you can just move all the "Unknown" faces to 
-    "Ignore", otherise it may take some time to manually clean up from within digiKam (or by editing digikam4.db using
-    an SQL client).  
+    "Ignore", otherwise it may take some time to manually clean up from within digiKam (or by editing digikam4.db using
+    an SQL client).
 10. If you want, you can now run digiKam's face detection to detect faces that Picasa hadn't detected or that were still
-    in the "Unknown" folder in Picasa.  
+    in the "Unknown" folder in Picasa.

--- a/digikam_db.py
+++ b/digikam_db.py
@@ -153,6 +153,16 @@ class DigikamDb(object):
         """Returns the ID of the person tag, or None if it does not exist."""
         return self._fetchcell('SELECT id FROM Tags WHERE pid = ? AND name = ?', (self.person_root_tag, person_name))
 
+    def find_person_name(self, id: int) -> Optional[str]:
+        """Returns the Name of the person name, or None if it does not exist."""
+        logging.info('SELECT name FROM Tags WHERE id = %s' % id)
+        name = self._fetchcell('SELECT name FROM Tags WHERE id = %s' % id)
+        logging.info('fetchcell OK')
+        logging.info('name=%s' % name)
+        if name == None:
+            name = ""
+        return name 
+
     def find_or_create_person_tag(self, person_name: str, dry_run: bool) -> int:
         """Returns the ID of a possibly newly created person tag with the given name."""
         tag_id = self.find_person_tag(person_name)
@@ -174,6 +184,11 @@ class DigikamDb(object):
         return self._fetchcell(
             'SELECT tagid FROM ImageTags WHERE imageid = ? AND tagid = ?',
             (image_id, tag_id)) is not None
+
+    def image_has_property(self, image_id: int, propname: str, rect: str) -> bool:
+        """Returns true if the given image already has the given property. Useful to find same rect."""
+        return self._fetchcell(
+            f"SELECT tagid FROM ImageTagProperties WHERE imageid = {image_id} AND property = '{propname}' AND value = '{rect}'") is not None
 
     def image_has_pick_tag(self, image_id: int) -> bool:
         """Returns true if the given image has any of the (four) "Pick" tags."""

--- a/digikam_db.py
+++ b/digikam_db.py
@@ -82,7 +82,7 @@ class DigikamDb(object):
     def close(self):
         self.conn.close()
 
-    def find_album_by_dir(self, path: Path) -> int:
+    def find_album_by_dir(self, path: Path) -> Optional[int]:
         """Returns ID of the Album that contains the given path."""
         for root_path, root_id in self.album_roots.items():
             try:
@@ -96,7 +96,8 @@ class DigikamDb(object):
             album_id = self._fetchcell('SELECT id FROM Albums WHERE albumRoot = ? AND relativePath = ?',
                                        (root_id, relative_path))
             if album_id is None:
-                raise ValueError('No digiKam Album found for %s (relative path %s) under root %s' % (path, relative_path, root_id))
+                logging.warning('No digiKam Album found for %s (relative path %s) under root %s' % (path, relative_path, root_id))
+                return None
             return album_id
         raise ValueError('No digiKam AlbumRoot found for %s, only have %s' % (path, self.album_roots))
 

--- a/digikam_db.py
+++ b/digikam_db.py
@@ -23,7 +23,7 @@ class DigikamDb(object):
 
     def __init__(self, file: Path):
         self.file = file
-        logging.info("file=%s" % file)
+        logging.debug("file=%s" % file)
         self.conn = sqlite3.connect(file)
         if os.name == 'nt':  # Windows
             import win32api  # From the pywin32 PIP package.
@@ -33,7 +33,7 @@ class DigikamDb(object):
                 if serial < 0:
                     serial = serial + (1 << 32)  # Convert int32 to uint32
                 serial_to_mountpoints.setdefault(serial, set()).add(sdiskpart.mountpoint)
-            logging.info('serial_to_mountpoints=%s' % serial_to_mountpoints)
+            logging.debug('serial_to_mountpoints=%s' % serial_to_mountpoints)
             def volume_uuid_to_mountpoints(uuid: str) -> Set[str]:
                 # On Windows, digiKam uses the serial number in hex format as the UUID:
                 # https://invent.kde.org/frameworks/solid/-/blob/006e013d18c20cf2c98cf1776d768476978a1a63/src/solid/devices/backends/win/winstoragevolume.cpp#L57
@@ -42,7 +42,7 @@ class DigikamDb(object):
             dev_to_mountpoints: Dict[str, Set[str]] = {}
             for sdiskpart in psutil.disk_partitions():
                 dev_to_mountpoints.setdefault(sdiskpart.device, set()).add(sdiskpart.mountpoint)
-            logging.info('dev_to_mountpoints=%s' % dev_to_mountpoints)
+            logging.debug('dev_to_mountpoints=%s' % dev_to_mountpoints)
             def volume_uuid_to_mountpoints(uuid: str) -> Set[str]:
                 # On Unix, we use a trick with realpath and /dev/disk/by-uuid' to find the main mount point.
                 return dev_to_mountpoints[os.path.realpath(Path('/dev/disk/by-uuid') / uuid.upper())]
@@ -51,9 +51,9 @@ class DigikamDb(object):
         for row in self.conn.cursor().execute('SELECT id, type, identifier, specificPath FROM AlbumRoots WHERE status = 0'):
             id, type, identifier, specific_path = row
             if type != 1 and type != 2 and type != 3:  # 0=Undefined, 1=VolumeHardWired, 2=VolumeRemovable, 3=Network
-                logging.info('Skipping album %s at %s on %s because it is not a local disk' % (id, specific_path, identifier))
+                logging.info('Skipping album %s at %s on %s because it is not recognized disk type' % (id, specific_path, identifier))
                 continue
-            logging.info('id=%s specific_path=%s identifier=%s' % (id, specific_path, identifier))
+            logging.debug('id=%s specific_path=%s identifier=%s' % (id, specific_path, identifier))
             if identifier.startswith('volumeid:?uuid='):
                 if specific_path.startswith('/'):
                     specific_path = specific_path[1:]
@@ -66,7 +66,7 @@ class DigikamDb(object):
             else:
                 raise ValueError('Unsupported volume type %s' % identifier)
                 
-        logging.info('album_roots=%s' % self.album_roots)
+        logging.debug('album_roots=%s' % self.album_roots)
 
         self.person_root_tag = self._detect_person_root_tag()
         self.internal_tags_id = self.find_tag(0, _INTERNAL_ROOT_TAG_NAME)
@@ -153,16 +153,6 @@ class DigikamDb(object):
         """Returns the ID of the person tag, or None if it does not exist."""
         return self._fetchcell('SELECT id FROM Tags WHERE pid = ? AND name = ?', (self.person_root_tag, person_name))
 
-    def find_person_name(self, id: int) -> Optional[str]:
-        """Returns the Name of the person name, or None if it does not exist."""
-        logging.info('SELECT name FROM Tags WHERE id = %s' % id)
-        name = self._fetchcell('SELECT name FROM Tags WHERE id = %s' % id)
-        logging.info('fetchcell OK')
-        logging.info('name=%s' % name)
-        if name == None:
-            name = ""
-        return name 
-
     def find_or_create_person_tag(self, person_name: str, dry_run: bool) -> int:
         """Returns the ID of a possibly newly created person tag with the given name."""
         tag_id = self.find_person_tag(person_name)
@@ -185,10 +175,10 @@ class DigikamDb(object):
             'SELECT tagid FROM ImageTags WHERE imageid = ? AND tagid = ?',
             (image_id, tag_id)) is not None
 
-    def image_has_property(self, image_id: int, propname: str, rect: str) -> bool:
-        """Returns true if the given image already has the given property. Useful to find same rect."""
+    def image_has_property(self, image_id: int, propname: str, value: str) -> bool:
+        """Returns true if the given image already has the given property."""
         return self._fetchcell(
-            f"SELECT tagid FROM ImageTagProperties WHERE imageid = {image_id} AND property = '{propname}' AND value = '{rect}'") is not None
+            f"SELECT tagid FROM ImageTagProperties WHERE imageid = {image_id} AND property = '{propname}' AND value = '{value}'") is not None
 
     def image_has_pick_tag(self, image_id: int) -> bool:
         """Returns true if the given image has any of the (four) "Pick" tags."""

--- a/digikam_db.py
+++ b/digikam_db.py
@@ -97,7 +97,6 @@ class DigikamDb(object):
                                        (root_id, relative_path))
             if album_id is None:
                 logging.warning('No digiKam Album found for %s (relative path %s) under root %s' % (path, relative_path, root_id))
-                return None
             return album_id
         raise ValueError('No digiKam AlbumRoot found for %s, only have %s' % (path, self.album_roots))
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,9 @@ def init_argparse() -> ArgumentParser:
     parser.add_argument('--photos_dir', required=True, type=Path,
                         help='Path to a root directory with photos and picasa.ini files to be imported')
     parser.add_argument('--digikam_db', required=True, type=Path,
-                        help='Path do digiKam\'s digikam4.db file.')
+                        help='Filename of digiKam\'s digikam4.db file.')
+    parser.add_argument('--contacts', required=False, type=Path,
+                        help='Optional filename of Picasa''s contacts.xml file')
     parser.add_argument('--dry_run', action='store_true')
     parser.add_argument('--verbose', '-v', action='count', default=0,
                         help='Log verbosity. Pass -vv to see debug output.')
@@ -47,7 +49,9 @@ def main() -> None:
 
     logging.info('Traversing input directories')
     with db.conn:  # Transaction
-        migrator.migrate_directories_under(input_root_dir=args.photos_dir, db=db, dry_run=args.dry_run)
+        migrator.migrate_directories_under(input_root_dir=args.photos_dir, db=db, 
+                                           dry_run=args.dry_run,
+                                           contacts_file=args.contacts)
     db.close()
 
     logging.info('Done')

--- a/migrator.py
+++ b/migrator.py
@@ -20,78 +20,64 @@ _FACE_TAG_REGION_PROPERTY = 'tagRegion'
 
 ContactTags = Dict[str, Optional[int]]
 GlobalNames = Dict[str, str] # maps contact_id to name globally (but may be overridden per directory)
+ContactID2NamesSet = Dict[str, Set[str]]
 
 def _is_photo_file(file: str) -> bool:
     file = file.lower()
     return file.endswith('.jpg') or file.endswith('.jpeg') or file.endswith('.raw') or file.endswith('.psd')
 
-def learn_contact_ids(input_dir: Path, ini_file_name: str, contact_id_2_nameset: Dict[str, set]):
-    """ Learn contact_id to name mapping from [Contacts2] sections of .ini file"""
+def learn_contact_ids(input_dir: Path, ini_file_name: str, contact_id_2_nameset: ContactID2NamesSet):
+    """Learn contact_id to name mapping from [Contacts2] sections of .ini file"""
     # Read ini file.
-    #logging.info("learn_contact_ids: input_dir=%s" % input_dir)
     ini = configparser.ConfigParser(strict=False)
-    ini_file = input_dir / Path(ini_file_name)
+    # Note: Python 3.10.4 on Windows needs the cast to Path below
+    ini_file = Path(input_dir) / ini_file_name
     ini.read(ini_file, encoding='utf8')
-    try:
-        for contact_id, value in ini['Contacts2'].items():
-            person_name = value.split(';')[0]
-            if not contact_id in contact_id_2_nameset:
-                logging.info(f"Learned name for {contact_id}='{person_name}' from {ini_file}")
-                contact_id_2_nameset[contact_id]=set([person_name])
-            else:
-                if person_name not in contact_id_2_nameset[contact_id]:
-                     logging.warning(f"Learned additional name for {contact_id}='{person_name}' from {ini_file}")
-                contact_id_2_nameset[contact_id].add(person_name)
-    except KeyError:
-        # likely no Contacts2 section
-        pass
-    except Exception as e:
-        logging.warning("Exception while learning contact ids")
-        logging.exception(str(e))
+    if 'Contacts2' in ini:
+        try:
+            for contact_id, value in ini['Contacts2'].items():
+                person_name = value.split(';')[0]
+                if contact_id not in contact_id_2_nameset:
+                    logging.info(f"Learned name for {contact_id}='{person_name}' from {ini_file}")
+                    contact_id_2_nameset[contact_id] = set([person_name])
+                else:
+                    if person_name not in contact_id_2_nameset[contact_id]:
+                        logging.warning(f"Learned additional name for {contact_id}='{person_name}' from {ini_file}")
+                    contact_id_2_nameset[contact_id].add(person_name)
+        except Exception as e:
+            logging.warning("Exception while learning contact ids")
+            logging.exception(str(e))
 
-def learn_old_contact_ids(input_dir: Path, ini_file_name: str, contact_id_2_nameset: Dict[str, set]):
-    """ Learn contact_id to name mapping from old [Contacts] sections of .ini file"""
-    # Prerequisite: Must have learned all that is possible from new [Contacts2] already
-
-    # Read ini file.
-    #logging.info("learn_old_contact_ids: input_dir=%s" % input_dir)
-    ini = configparser.ConfigParser(strict=False)
-    ini_file = input_dir /  Path(ini_file_name)
-    ini.read(ini_file, encoding='utf8')
-    try:
-        for contact_id, value in ini['Contacts'].items():
-            person_name = ".NoName-"+value.split(',')[1] # this is actually a hash
-            if not contact_id in contact_id_2_nameset:
-                logging.info(f"Learned name (old picasa contact ID) for {contact_id}='{person_name}' from {ini_file}")
-                contact_id_2_nameset[contact_id]=set([person_name])
-            # Note: the difference between learn_contact_ids and this version is we don't add the name to the set
-    except KeyError:
-        # likely no Contacts2 section
-        pass
-    except Exception as e:
-        logging.warning("Exception while learning contact ids")
-        logging.exception(str(e))
+    if 'Contacts' in ini:
+        try:
+            for contact_id, value in ini['Contacts'].items():
+                picasa_name_hash = value.split(',')[1]
+                person_name = f".NoName-{picasa_name_hash}"
+                if contact_id not in contact_id_2_nameset:
+                    logging.info(f"Learned old picasa name hash for {contact_id}='{person_name}' from {ini_file}")
+                    contact_id_2_nameset[contact_id] = set([person_name])
+                # Note: the difference between learn_Contacts2_and this version is we don't add the name to the set
+        except Exception as e:
+            logging.warning("Exception while learning contact ids")
+            logging.exception(str(e))
 
 def migrate_directories_under(input_root_dir: Path, 
                               db: DigikamDb, 
                               dry_run: bool,
-                              contacts_file: Path):
+                              contacts_file: Optional[Path],
+                              skip_same_rect: Optional[bool]):
     """Traverses directory tree to find directories to migrate."""
 
     # Build a contact_id to name(s) dictionary
     global_names: GlobalNames = {}
 
     if contacts_file is not None:
-        # contacts.xml seems more authoratative than *.ini files
+        # contacts.xml seems more authoritative than *.ini files
         # Use this whenever possible.
-        # Can be found at %LocalAppData%\Google\Picasa2\contacts\contacts.xml
-        # Also can be obtained from performing a backup operation from 
-        # within Picasa.  It will be in the backup location as 
-        # $Application Data\Google\Picasa2\contacts\backup.xml
-        logging.info(f'Reading contacts from {contacts_file}')
+        logging.debug(f'Reading contacts from {contacts_file}')
         tree = ET.parse(contacts_file)
         for contact in tree.getroot():
-            logging.info(f'{contact.attrib}')
+            logging.debug(f'{contact.attrib}')
             global_names[contact.attrib['id']] = contact.attrib['name']
 
     else:
@@ -99,57 +85,50 @@ def migrate_directories_under(input_root_dir: Path,
         # Sometimes names will be missing or conflicting if found 
         # different in multiple directories.  Conflicting names
         # will be merged by this script by concatenating them with " | " 
-        # separators in sorted order.  Missing names will have an
-        # auto generated value of  
-        contact_id_2_nameset: Dict[str, set] = {}
+        # separators in sorted order.  
+        contact_id_2_nameset: ContactID2NamesSet = {}
         for input_dir, subdirs, files in os.walk(input_root_dir):
             for ini_file in (_PICASA_INI_FILE,_OLD_PICASA_INI_FILE):
                 learn_contact_ids(input_dir,ini_file,contact_id_2_nameset)
-        for input_dir, subdirs, files in os.walk(input_root_dir):
-            for ini_file in (_PICASA_INI_FILE,_OLD_PICASA_INI_FILE):
-                learn_old_contact_ids(input_dir,ini_file,contact_id_2_nameset)
 
-        logging.info("contact_id_2_nameset")
-        logging.info("------------------------------------------------------------")
-        try:
-            for contact_id, names in contact_id_2_nameset.items():
-                person_name = ""
-                for i, item in enumerate(sorted(names)):
-                    person_name += item
-                    if i < (len(names)-1):
-                        # ambiguous contact_id will have a concatenated list of names
-                        person_name += "|"
-                logging.info(f"'{contact_id}': '{person_name}'")
-                # Create or add contacts
-                global_names[contact_id] = person_name
-        except Exception as e:
-            logging.warning(f"Exception: {e}")
-        logging.info("------------------------------------------------------------")
+        global_names = {k: "|".join(sorted(v)) for k,v in contact_id_2_nameset.items()}
+
+        logging.debug(f"global_names={global_names}")
 
     contact_tags_per_dir: Dict[Path, ContactTags] = {}
 
-    for ini_file in (_PICASA_INI_FILE,_OLD_PICASA_INI_FILE):
-        for input_dir, subdirs, files in os.walk(input_root_dir):
-            dir = Path(input_dir)
-            logging.info(f"Processing {Path(dir/ini_file)}")
-            try:
-                if ini_file in files:
-                    contact_tags_per_dir[dir] = migrate_directory(dir, files, db, 
-                                                    contact_tags_per_dir, global_names,
-                                                    dry_run=dry_run, ini_file_name=ini_file)
-                elif any([_is_photo_file(file) for file in files]):
-                    logging.warning(f'Found photos but no {ini_file} in {dir}')
-            except Exception as e:
-                # Seems to happen with very old "Originals" directories
-                logging.warning(f'Exception: {e}')
-                logging.warning(traceback.format_exc())
-    #logging.info("Final contact_tags_per_dir=%s" % contact_tags_per_dir)
+    for input_dir, subdirs, files in os.walk(input_root_dir):
+        dir = Path(input_dir)
+        if _PICASA_INI_FILE in files:
+            ini_file = _PICASA_INI_FILE
+        elif _OLD_PICASA_INI_FILE in files:
+            ini_file = _OLD_PICASA_INI_FILE
+        else:
+            if any([_is_photo_file(file) for file in files]):
+                logging.warning(f'Found photos but no .ini in {dir}')
+            else:
+                logging.warning(f"No photos and no .ini file in {dir}")
+            continue
+        logging.debug(f"Processing {Path(dir/ini_file)}")
+        try:
+            contact_tags_per_dir[dir] = migrate_directory(dir, files, db, 
+                                        contact_tags_per_dir, global_names,
+                                        dry_run=dry_run, ini_file_name=ini_file,
+                                        contacts_file=contacts_file,
+                                        skip_same_rect=skip_same_rect)
+        except Exception as e:
+            # Seems to happen with very old "Originals" directories. digiKam Windows version
+            # will skip these directories, leading to this exception
+            logging.warning(f'Exception: {e}')
+            logging.warning(traceback.format_exc())
 
 def migrate_directory(input_dir: Path, files: List[str], db: DigikamDb,
                       contact_tags_per_dir: Dict[Path, ContactTags],
                       global_names: GlobalNames,
                       dry_run: bool,
-                      ini_file_name: str) -> ContactTags:
+                      ini_file_name: str,
+                      contacts_file: Optional[str],
+                      skip_same_rect: Optional[bool]) -> ContactTags:
     """Migrates metadata of all photo files in the given directory."""
     logging.info('===========================================================================================')
     if input_dir.name == '.picasaoriginals':
@@ -171,7 +150,7 @@ def migrate_directory(input_dir: Path, files: List[str], db: DigikamDb,
     album_to_tag = _map_albums_to_tags(ini, db, used_ini_sections, dry_run=dry_run)
 
     self_contact_to_tag = _map_contacts_to_tags(ini['Contacts2'], db, dry_run=dry_run) if 'Contacts2' in ini else {}
-    logging.info('self_contact_to_tag=%s' % self_contact_to_tag)
+    logging.debug('self_contact_to_tag=%s' % self_contact_to_tag)
     
     # Merge contacts declared in parent ini files.
     contact_to_tag = self_contact_to_tag.copy()
@@ -182,18 +161,17 @@ def migrate_directory(input_dir: Path, files: List[str], db: DigikamDb,
             else:
                 contact_to_tag[contact_id] = tag_id
 
-    #logging.info("contact_to_tag=%s" % contact_to_tag)
-
     # Migrate file by file.
     for filename in filter(_is_photo_file, files):
         if filename not in album_images:
-            raise ValueError('digiKam does not know %s' % (input_dir / filename))
+            raise ValueError(f'digiKam does not know {(input_dir / filename)}')
         image_id = album_images[filename]
         if ini.has_section(filename):
             used_ini_sections.add(filename)
             ini_section = ini[filename]
             try:
-                migrate_file(filename, image_id, ini_section, db, album_to_tag, contact_to_tag, global_names, dry_run=dry_run)
+                migrate_file(filename, image_id, ini_section, db, album_to_tag, contact_to_tag, global_names, 
+                             skip_same_rect=skip_same_rect, contacts_file=contacts_file, dry_run=dry_run)
             except Exception as e:
                 logging.error(f"Exception: {e}")
                 logging.error(traceback.format_exc())
@@ -216,7 +194,9 @@ def migrate_file(filename: str, image_id: int, ini_section: configparser.Section
                  album_to_tag: Dict[str, int],     # Picasa ID -> digiKam Tag ID
                  contact_to_tag: ContactTags,      # Picasa contact ID -> digiKam Tag ID (local to this directory branch -- use this if possible, but might not be complete)
                  global_names: GlobalNames,        # Picasa contact ID -> name (global to whole picasa source tree -- might be ambiguous)
-                 dry_run: bool):
+                 dry_run: bool,
+                 contacts_file: Optional[str],
+                 skip_same_rect: Optional[bool]):
     # Note: Picasa's rotate=rotate(N) means 0=normal, 1=90º, 2=180º, 3=270º clock-wise. This does *not* influence the
     # face coordinates, which are wrt. the image file stored on disk.
     used_ini_keys = {'backuphash', 'rotate'}
@@ -247,7 +227,9 @@ def migrate_file(filename: str, image_id: int, ini_section: configparser.Section
             logging.warning('Skipping faces on %s because of PSD format' % filename)
         else:
             for face_data in faces.split(';'):
-                migrate_face(image_id, filename, face_data, db, contact_to_tag, global_names, dry_run=dry_run)
+                migrate_face(image_id, filename, face_data, db, contact_to_tag, global_names, 
+                             contacts_file=contacts_file, skip_same_rect=skip_same_rect, 
+                             dry_run=dry_run)
 
     unused_ini_keys = set(ini_section.keys()) - used_ini_keys
     if unused_ini_keys:
@@ -260,25 +242,43 @@ def migrate_face(image_id: int,
                  db: DigikamDb, 
                  contact_to_tag: ContactTags, 
                  global_names: GlobalNames,
-                 dry_run: bool):
+                 dry_run: bool,
+                 contacts_file: Optional[str],
+                 skip_same_rect: Optional[bool]):
     face_data = face_data.split(',')
     assert len(face_data) == 2
     if face_data[1] == _UNKNOWN_FACE_ID:
         return
     contact_id = face_data[1]
-    if contact_id not in contact_to_tag:
-        if contact_id not in global_names:
-            # This can happen often if not using contacts.xml
-            # Add to global
-            person_name = ".NoName-"+contact_id+"-from-rect64"
+
+    tag_id = None
+
+    if contacts_file == None:
+        # Names from local directory's .ini files have higher priority
+        if contact_id in contact_to_tag:
+            tag_id = contact_to_tag[contact_id]
+        else:
+            if contact_id not in global_names:
+                # This can happen often if not using contacts.xml
+                # Add to global
+                person_name = f".NoName-{contact_id}-from-rect64"
+                logging.info(f'Learned {person_name} from a rect64 tag belonging to {filename}')
+                global_names[contact_id] = person_name
+            tag_id = db.find_or_create_person_tag(global_names[contact_id], dry_run=dry_run)
+            contact_to_tag[contact_id] = tag_id;
+    else:
+        # global_names (learned from contacts.xml) has higher priority
+        if (contact_id in global_names):
+            tag_id = db.find_or_create_person_tag(global_names[contact_id], dry_run=dry_run)
+            contact_to_tag[contact_id] = tag_id;
+        elif (contact_id in contact_to_tag):
+            tag_id = contact_to_tag[contact_id]
+        else:
+            person_name = f".NoName-{contact_id}-from-rect64"
             logging.info(f'Learned {person_name} from a rect64 tag belonging to {filename}')
             global_names[contact_id] = person_name
-        tag_id = db.find_or_create_person_tag(global_names[contact_id], dry_run=dry_run)
-    else:
-        tag_id = contact_to_tag[contact_id]
-
-    if tag_id is None:
-        return  # Skip silently, as _map_contacts_to_tags() already warns about unmapped contacts.
+            tag_id = db.find_or_create_person_tag(person_name, dry_run=dry_run)
+            contact_to_tag[contact_id] = tag_id;
 
     if db.image_has_tag(image_id, tag_id):
         logging.warning(
@@ -293,14 +293,17 @@ def migrate_face(image_id: int,
     # Not sure if skipping an existing rect is an improvement or not... probably not since DigiKam creates rects at scan time
     # and if the same rect is found in Picasa, it won't migrate.
     # Should NOT skip if it is the first attempt at migration. however if you don't skip and identify the rect as someone else
-    # and then run this script again, you end up with another rect mapped to Picasa's name -- it's a connundrum..
-    skip_same_rect=False 
-    if skip_same_rect and db.image_has_property(image_id, _FACE_TAG_REGION_PROPERTY, digikam_rect):
-        logging.warning(
-            f'Not applying face {tag_id} ({contact_id}) to {image_id} ({filename}) because it already has that face rectangle')
-        return
+    # and then run this script again, you end up with another rect mapped to Picasa's name -- it's a conundrum..
+    if db.image_has_property(image_id, _FACE_TAG_REGION_PROPERTY, digikam_rect):
+        if skip_same_rect == None:
+            logging.error(f"digiKam already has face rectangle {digikam_rect} defined.  Please specify what to do by running with argument --skip_same_rect or --no-skip_same_rect")
+            assert(skip_same_rect is not None)
+        elif skip_same_rect:
+            logging.warning(
+                f'Not applying face {tag_id} ({contact_id}) to {image_id} ({filename}) because it already has that face rectangle')
+            return
 
-    logging.debug('Adding face %s (%s) at %s to %s (%s)' % (tag_id, contact_id, digikam_rect, image_id, filename))
+    logging.debug(f'Adding face {tag_id} ({contact_id}) at {digikam_rect} to {image_id} ({filename})')
     if dry_run:
         return
 
@@ -339,5 +342,5 @@ def _map_contacts_to_tags(
     for contact_id, value in contacts_section.items():
         person_name = value.split(';')[0]
         result[contact_id] = db.find_or_create_person_tag(person_name, dry_run=dry_run)
-        logging.info("person_name=%s contact_id=%s tag=%s" % (person_name, contact_id, result[contact_id]))
+        logging.debug("person_name=%s contact_id=%s tag=%s" % (person_name, contact_id, result[contact_id]))
     return result

--- a/migrator.py
+++ b/migrator.py
@@ -104,17 +104,11 @@ def migrate_directories_under(input_root_dir: Path,
                 logging.warning(f"No photos and no .ini file in {dir}")
             continue
         logging.debug(f"Processing {Path(dir/ini_file)}")
-        try:
-            contact_tags_per_dir[dir] = migrate_directory(dir, files, db,
-                	contact_tags_per_dir, global_names,
-                	dry_run=dry_run, ini_file_name=ini_file,
-                	prioritize_global_names=prioritize_global_names,
-                	skip_same_rect=skip_same_rect)
-        except Exception as e:
-            # Seems to happen with very old "Originals" directories. digiKam Windows version
-            # will skip these directories, leading to this exception
-            logging.warning(f'Exception: {e}')
-            logging.warning(traceback.format_exc())
+        contact_tags_per_dir[dir] = migrate_directory(dir, files, db,
+            	contact_tags_per_dir, global_names,
+            	dry_run=dry_run, ini_file_name=ini_file,
+            	prioritize_global_names=prioritize_global_names,
+            	skip_same_rect=skip_same_rect)
 
 def migrate_directory(input_dir: Path, files: List[str], db: DigikamDb,
                       contact_tags_per_dir: Dict[Path, ContactTags],

--- a/rect64.py
+++ b/rect64.py
@@ -7,7 +7,7 @@ def parse_rect64(data: str) -> Tuple[float, float, float, float]:  # left, top, 
     # Strip the rect64() from the outside.
     assert data.startswith("rect64(") and data.endswith(")"), input
     data = data[7:-1]
-    logging.info("data=%s" % data)
+    #logging.info("data=%s" % data)
     assert len(data) >= 1
     data = data.zfill(16)  # Zeros in front, as Picasa abbreviates.
     # noinspection PyTypeChecker

--- a/rect64.py
+++ b/rect64.py
@@ -7,7 +7,6 @@ def parse_rect64(data: str) -> Tuple[float, float, float, float]:  # left, top, 
     # Strip the rect64() from the outside.
     assert data.startswith("rect64(") and data.endswith(")"), input
     data = data[7:-1]
-    #logging.info("data=%s" % data)
     assert len(data) >= 1
     data = data.zfill(16)  # Zeros in front, as Picasa abbreviates.
     # noinspection PyTypeChecker


### PR DESCRIPTION
+ Support old Picasa.ini file
+ Support old [Contacts] section in .ini files
+ Create global_names dict
+ Support contacts.xml
+ Prescan contacts.xml or all .ini files prior to reading face rects
  (takes care of case where contact-id was defined only in contacts.xml
  or in a sibling directory branch instead of directly above in tree)
+ Autogen names if not in any .ini file nor contacts.xml